### PR TITLE
fix: main ctr+c / quit에 대해 클라이언트만 정상 종료 #59

### DIFF
--- a/srcs/Makefile
+++ b/srcs/Makefile
@@ -18,7 +18,6 @@ SRCS = main.cpp \
 		Auth.cpp \
 		command/Topic.cpp \
 		command/Privmsg.cpp \
-		command/Quit.cpp \
 
 OBJS = $(SRCS:.cpp=.o)
 DEPS = $(SRCS:.cpp=.d)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -151,8 +151,8 @@ Command *Server::createCommand(UserInfo &user, std::string recvStr)
 		cmd = new Invite(&msg, user, &this->channels, &this->users);
 	else if (msg.getCommand() == "TOPIC")
 		cmd = new Topic(&msg, user, this->channels, serverName);
-	else if (msg.getCommand() == "QUIT")
-		cmd = new Quit(&msg, user, &this->channels, &this->users);
+	//else if (msg.getCommand() == "QUIT")
+	//	cmd = new Quit(&msg, user, &this->channels, &this->users);
 	else if (msg.getCommand() == "PRIVMSG")
 		cmd = new Privmsg(&msg, user, this->users, this->channels);
 

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -27,7 +27,7 @@
 #include "Auth.hpp"
 #include "command/Topic.hpp"
 #include "command/Privmsg.hpp"
-#include "command/Quit.hpp"
+//#include "command/Quit.hpp"
 
 class UserInfo;
 class Command;

--- a/srcs/command/Quit.cpp
+++ b/srcs/command/Quit.cpp
@@ -4,3 +4,11 @@ Quit::Quit(Message *msg, UserInfo &user, std::map<std::string, Channel> *channel
 	this->channels = channels;
 	this->users = users;
 }
+
+void Quit::execute() {
+	// 유저가 join한 채널 확인 후 채널 순회하면서 해당 채널의 users, operator, invite 목록 삭제
+	
+	// 서버 내 users에서 해당 유저 삭제 
+
+	// response message
+}


### PR DESCRIPTION
> 기존 코드 무한루프 해결

-  revents에 17이 들어옴 -> pollhup or pollerr를 합친 값
- pollin에도 조건이 포함되므로 pollin에 걸림
- 클라이언트 종료 시 서버 무한루프&꺼지는 문제 발생

- pollhup || pollerr if문 앞으로 빼고 close 처리함